### PR TITLE
Dependency resolution for npm in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "@radix-ui/react-toast": "^1.1.5",
     "@radix-ui/react-tooltip": "^1.0.7",
     "@vercel/analytics": "^1.2.2",
-    "@vercel/kv": "^1.0.1",
     "ai": "latest",
     "cheerio": "^1.0.0-rc.12",
     "class-variance-authority": "^0.7.0",


### PR DESCRIPTION
## Description

#### @langchain/community, llm-answer-engine, and langchain require different  minor requirements for @vercel/kv. Langchain and langchain/community both require ^0.0.23 vs ^1.0.1 in llm-answer-engine repo. I removed that line and also recommend creating a package.lock file and committing. 

Let me know if anything else is needed.
