### PR TITLE
feat: add Tavily as a search provider alongside Serper, Brave, Google

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,8 @@ OPENAI_API_KEY=APIKEYGOESHERE
 SERPER_API=APIKEYGOESHERE
 # Brave Search API Key (Serper is the default, brave is an alternative option for search)
 BRAVE_SEARCH_API_KEY=APIKEYGOESHERE
+# OPTIONAL - Tavily Search API Key (alternative search provider)
+TAVILY_API_KEY=APIKEYGOESHERE
 
 
 # OPTIONAL - Set LAN GPU server, examples:

--- a/app/config.tsx
+++ b/app/config.tsx
@@ -7,7 +7,7 @@
 export const config = {
     useOllamaInference: false,
     useOllamaEmbeddings: false,
-    searchProvider: 'serper', // 'serper', 'google' // 'serper' is the default
+    searchProvider: 'serper', // 'serper', 'google', 'brave', 'tavily' // 'serper' is the default
     inferenceModel: 'llama-3.1-70b-versatile', // Groq: 'mixtral-8x7b-32768', 'gemma-7b-it' // OpenAI: 'gpt-3.5-turbo', 'gpt-4' // Ollama 'mistral', 'llama3' etc
     inferenceAPIKey: process.env.GROQ_API_KEY, // Groq: process.env.GROQ_API_KEY // OpenAI: process.env.OPENAI_API_KEY // Ollama: 'ollama' is the default
     embeddingsModel: 'text-embedding-3-small', // Ollama: 'llama2', 'nomic-embed-text' // OpenAI 'text-embedding-3-small', 'text-embedding-3-large'

--- a/app/tools/searchProviders.tsx
+++ b/app/tools/searchProviders.tsx
@@ -1,6 +1,7 @@
 "use server";
 import { SearchResult } from '@/components/answer/SearchResultsComponent';
 import { config } from '../config';
+import { tavily } from '@tavily/core';
 
 export async function getSearchResults(userMessage: string): Promise<any> {
     switch (config.searchProvider) {
@@ -10,6 +11,8 @@ export async function getSearchResults(userMessage: string): Promise<any> {
             return serperSearch(userMessage);
         case "google":
             return googleSearch(userMessage);
+        case "tavily":
+            return tavilySearch(userMessage);
         default:
             return Promise.reject(new Error(`Unsupported search provider: ${config.searchProvider}`));
     }
@@ -94,6 +97,22 @@ export async function serperSearch(message: string, numberOfPagesToScan = config
             favicon: result.favicons?.[0] || ''
         }));
         return final
+    } catch (error) {
+        console.error('Error fetching search results:', error);
+        throw error;
+    }
+}
+
+export async function tavilySearch(message: string, numberOfPagesToScan = config.numberOfPagesToScan): Promise<SearchResult[]> {
+    try {
+        const tvly = tavily({ apiKey: process.env.TAVILY_API_KEY as string });
+        const response = await tvly.search(message, { maxResults: numberOfPagesToScan });
+        const final = response.results.map((result: any): SearchResult => ({
+            title: result.title,
+            link: result.url,
+            favicon: `https://www.google.com/s2/favicons?domain=${new URL(result.url).hostname}&sz=128`
+        }));
+        return final;
     } catch (error) {
         console.error('Error fetching search results:', error);
         throw error;

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@langchain/community": "latest",
     "@langchain/openai": "^0.0.25",
     "@phosphor-icons/react": "^2.1.5",
+    "@tavily/core": "^0.6.1",
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-label": "^2.0.2",


### PR DESCRIPTION
## Summary

Adds Tavily as a fourth selectable search provider in the LLM answer engine, configured via `config.searchProvider = 'tavily'`.

### What changed
- **`app/tools/searchProviders.tsx`**: Added `tavilySearch()` function using `@tavily/core` SDK, mapping Tavily results to the existing `SearchResult` shape. Added `case 'tavily'` to the `getSearchResults()` switch. Favicons are derived from Google's favicon service using the result URL hostname.
- **`app/config.tsx`**: Updated the `searchProvider` comment to list `'tavily'` as a valid option.
- **`.env.example`**: Added `TAVILY_API_KEY=APIKEYGOESHERE` entry.
- **`package.json`**: Added `@tavily/core` (`^0.6.1`) to dependencies.

### Files changed
- `app/tools/searchProviders.tsx`
- `app/config.tsx`
- `.env.example`
- `package.json`

### Dependency changes
- Added `@tavily/core` (`^0.6.1`) to `package.json` dependencies

### Environment variable changes
- Added `TAVILY_API_KEY` (required when `searchProvider` is set to `'tavily'`)

### Notes for reviewers
- This is an **additive** change — existing Serper, Brave, and Google providers are untouched.
- To use Tavily, set `searchProvider: 'tavily'` in `app/config.tsx` and provide `TAVILY_API_KEY` in your environment.
- `npm install` has a pre-existing issue with `"latest"` version specs in package.json unrelated to this PR.

### Automated Review

- Passed after 1 attempt(s)
- Final review: The Tavily migration is a clean, additive implementation that correctly integrates @tavily/core as a fourth search provider. All four files mentioned in the plan were updated. The SDK usage is correct — `tavily({ apiKey })` client construction, `.search(query, { maxResults })`, and `response.results[].url`/`title` field mapping are all valid. The implementation is consistent in style and error handling with the existing Brave, Google, and Serper providers. No regressions introduced. Three minor issues noted but none are blocking.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/developersdigest/llm-answer-engine/pull/95" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->