### PR TITLE
feat: add Tavily search provider option to Express API

### DIFF
--- a/express-api/.env.example
+++ b/express-api/.env.example
@@ -4,3 +4,7 @@ OPENAI_API_KEY=APIKEYGOESHERE
 GROQ_API_KEY=APIKEYGOESHERE
 # https://brave.com/search/api/
 BRAVE_SEARCH_API_KEY=APIKEYGOESHERE
+# https://app.tavily.com
+TAVILY_API_KEY=APIKEYGOESHERE
+# Search provider: 'brave' (default) or 'tavily'
+SEARCH_PROVIDER=brave

--- a/express-api/index.js
+++ b/express-api/index.js
@@ -5,6 +5,7 @@ import { RecursiveCharacterTextSplitter } from 'langchain/text_splitter';
 import { OpenAIEmbeddings } from '@langchain/openai';
 import { MemoryVectorStore } from 'langchain/vectorstores/memory';
 import { BraveSearch }  from "@langchain/community/tools/brave_search";
+import { tavily } from "@tavily/core";
 import OpenAI from 'openai';
 import cheerio from 'cheerio';
 import dotenv from 'dotenv';
@@ -44,15 +45,28 @@ app.post('/', async (req, res) => {
   // 10. Define search engine function
   async function searchEngineForSources(message) {
     console.log(`3. Initializing Search Engine Process`);
-    // 11. Initialize BraveSearch
-    const loader = new BraveSearch({ apiKey: process.env.BRAVE_SEARCH_API_KEY });
+    const searchProvider = process.env.SEARCH_PROVIDER || 'brave';
     // 12. Rephrase the message
     const rephrasedMessage = await rephraseInput(message);
-    console.log(`6. Rephrased message and got documents from BraveSearch`);
-    // 13. Get documents from BraveSearch 
-    const docs = await loader.call(rephrasedMessage, { count: numberOfPagesToScan });
-    // 14. Normalize data
-    const normalizedData = normalizeData(docs);
+    let normalizedData;
+    if (searchProvider === 'tavily') {
+      // Tavily search path
+      console.log(`6. Rephrased message, searching with Tavily`);
+      const tvly = tavily({ apiKey: process.env.TAVILY_API_KEY });
+      const tavilyResponse = await tvly.search(rephrasedMessage, { maxResults: numberOfPagesToScan });
+      normalizedData = tavilyResponse.results
+        .filter((result) => result.title && result.url)
+        .slice(0, numberOfPagesToScan)
+        .map(({ title, url }) => ({ title, link: url }));
+    } else {
+      // 11. Initialize BraveSearch (default)
+      const loader = new BraveSearch({ apiKey: process.env.BRAVE_SEARCH_API_KEY });
+      console.log(`6. Rephrased message and got documents from BraveSearch`);
+      // 13. Get documents from BraveSearch
+      const docs = await loader.call(rephrasedMessage, { count: numberOfPagesToScan });
+      // 14. Normalize data
+      normalizedData = normalizeData(docs);
+    }
     // 15. Process and vectorize the content
     return await Promise.all(normalizedData.map(fetchAndProcess));
   }

--- a/express-api/package.json
+++ b/express-api/package.json
@@ -15,6 +15,7 @@
     "dotenv": "^16.4.5",
     "express": "^4.18.3",
     "langchain": "^0.1.25",
+    "@tavily/core": "^0.0.7",
     "openai": "^4.28.4"
   },
   "scripts": {


### PR DESCRIPTION
## Summary

Adds Tavily as a configurable, parallel search provider in the Express API while keeping the existing BraveSearch integration as the default.

- Imported `@tavily/core` and added a Tavily search path in `searchEngineForSources()`
- Provider is selected via `SEARCH_PROVIDER` env var (`'brave'` default, `'tavily'` to use Tavily)
- Tavily results are normalized to `{ title, link }` to match the existing BraveSearch output format

## Files changed

- `express-api/index.js` — Added Tavily import and conditional search path gated by `SEARCH_PROVIDER`
- `express-api/package.json` — Added `@tavily/core` dependency
- `express-api/.env.example` — Added `TAVILY_API_KEY` and `SEARCH_PROVIDER` entries

## Dependency changes

- Added `@tavily/core` ^0.0.7 to `express-api/package.json`

## Environment variable changes

- Added `TAVILY_API_KEY` — required when `SEARCH_PROVIDER=tavily`
- Added `SEARCH_PROVIDER` — optional, defaults to `brave`

## Notes for reviewers

- BraveSearch remains the default; no breaking changes
- The Tavily path reuses the existing `fetchAndProcess` pipeline (cheerio scraping + vectorization) for consistency


### Automated Review

- Passed after 1 attempt(s)
- Final review: The migration correctly adds Tavily as a configurable search provider alongside BraveSearch in the Express API. All three files listed in the plan are modified. The Tavily SDK is imported and used with correct patterns, the dependency is added to package.json, and environment variables are documented in .env.example. No regressions to the existing Brave path are introduced. A few minor issues exist but none are blocking.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/developersdigest/llm-answer-engine/pull/96" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->